### PR TITLE
Fix/json import error handling

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-USERNAME=root
-PASSWORD=biboy_2006

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ target/
 .project
 .settings/
 bin/
+
+.env

--- a/src/main/java/com/studyapp/service/JsonImportExportService.java
+++ b/src/main/java/com/studyapp/service/JsonImportExportService.java
@@ -14,6 +14,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import com.studyapp.controller.CustomException;
 import com.studyapp.controller.MainController;
@@ -121,6 +122,8 @@ public class JsonImportExportService {
             // Single-deck format: { "deck_name": ..., "cards": [...] }
             return List.of(GSON.fromJson(obj, DeckJson.class));
 
+        } catch (JsonParseException e) {
+            throw new CustomException("Malformed JSON file: " + e.getMessage());
         } catch (IOException e) {
             throw new CustomException("Could not read file: " + e.getMessage());
         }


### PR DESCRIPTION
fix: catch JsonParseException in parseFile() to handle malformed JSON gracefully

Malformed JSON files previously caused uncaught runtime exceptions to
bubble up through the import flow, crashing the app with no user-facing
message. Added a catch block for JsonParseException (which covers
JsonSyntaxException) in parseFile() and wraps it in a CustomException,
consistent with the existing error-handling flow.